### PR TITLE
Be more forgiving when plotting blocking analysis.

### DIFF
--- a/pyblock/pd_utils.py
+++ b/pyblock/pd_utils.py
@@ -159,7 +159,10 @@ fig : :class:`matplotlib.figure.Figure`
 
         block = block_info.index.values
         std_err = block_info.ix[:,(col, 'standard error')].values
-        std_err_err = block_info.ix[:,(col, 'standard error error')].values
+        if 'standard error error' in block_info[col]:
+            std_err_err = block_info.ix[:,(col, 'standard error error')].values
+        else:
+            std_err_err = 0*std_err
         line = ax.errorbar(block, std_err, std_err_err, marker='o', label=col)
 
         # There should only be (at most) one non-null value for optimal block.


### PR DESCRIPTION
If no information for the error in the standard error is supplied, then
regard it as 0.  This is convenient if we're plotting data from
pyblock.error procedures which combine data items. Such procedures just
return the standard error and not the error associated with it (which
isn't particularly meaningful/helpful in the blocking analysis).
