### PR TITLE
Bug fix with multiplication in error.py

### DIFF
--- a/pyblock/error.py
+++ b/pyblock/error.py
@@ -117,8 +117,11 @@ ValueError
 
     if sign not in (1,-1):
         raise ValueError('sign must be either +1 or -1')
-    
-    mean = stats_A['mean'] / stats_B['mean']
+
+    if sign == 1:
+        mean = stats_A['mean'] * stats_B['mean']
+    else:
+        mean = stats_A['mean'] / stats_B['mean']
 
     std_err = mean*numpy.sqrt(
                 (stats_A['standard error']/stats_A['mean'])**2 +

--- a/pyblock/tests/test_error.py
+++ b/pyblock/tests/test_error.py
@@ -38,7 +38,7 @@ class ErrorTests(unittest.TestCase):
             self.assertAlmostEqual(self.ratio.ix[4,key], ratio[key], 8)
     def test_product_single(self):
         product = pyblock.error.product(self.reblock.ix[4,1], self.reblock.ix[4,2], self.cov_12[4], self.data_len[4])
-        benchmark = pd.Series({'mean':-0.08668955, 'standard error':0.24344343})
+        benchmark = pd.Series({'mean':-0.00561329, 'standard error':0.01576336})
         for key in ('mean', 'standard error'):
             self.assertAlmostEqual(benchmark[key], product[key], 8)
     def test_quad_raise(self):


### PR DESCRIPTION
Even if sign == 1 (which means that A and B should be multiplied),
the result given was A/B. This commit fixes this.