### PR TITLE
Add error propagation for addition and subtraction

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,7 @@ for mod_name in MOCK_MODULES:
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx', 'sphinx.ext.mathjax']
 if not os.environ.get('READTHEDOCS', None) == 'True':
-    extensions.append('sphinxcontrib.napoleon')
+    extensions.append('sphinx.ext.napoleon')
 numpydoc_show_class_members = False
 
 # Add any paths that contain templates here, relative to this directory.
@@ -136,7 +136,7 @@ else:
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/pyblock/blocking.py
+++ b/pyblock/blocking.py
@@ -11,12 +11,12 @@ def reblock(data, rowvar=1, ddof=None, weights=None):
 
 Repeatedly average neighbouring data points in order to remove the effect of
 serial correlation on the estimate of the standard error of a data set, as
-described by Flyvbjerg and Petersen [1]_.  The standard error is constant
+described by Flyvbjerg and Petersen [Flyvbjerg]_.  The standard error is constant
 (within error bars) once the correlation has been removed.
 
 If a weighting is provided then the weighted variance and standard error of
-each variable is calculated, as described in [2]_. Bessel correction is
-obtained using the "effective sample size" from [3]_.
+each variable is calculated, as described in [Pozzi]_. Bessel correction is
+obtained using the "effective sample size" from [Madansky]_.
 
 .. default-role:: math
 
@@ -59,12 +59,12 @@ block_info : :class:`list` of :func:`collections.namedtuple`
 
 References
 ----------
-.. [1]  "Error estimates on averages of correlated data", H. Flyvbjerg and
+.. [Flyvbjerg]  "Error estimates on averages of correlated data", H. Flyvbjerg,
    H.G. Petersen, J. Chem. Phys. 91, 461 (1989).
-.. [2]  "Exponential smoothing weighted correlations", F. Pozzi, T. Matteo,
-   and T. Aste, Eur. Phys. J. B. 85, 175 (2012).
-.. [3]  "An Analysis of WinCross, SPSS, and Mentor Procedures for Estimating
-   the Variance of a Weighted Mean", A. Madansky and H. G. B. Alexander,
+.. [Pozzi]  "Exponential smoothing weighted correlations", F. Pozzi, T. Matteo,
+   T. Aste, Eur. Phys. J. B. 85, 175 (2012).
+.. [Madansky]  "An Analysis of WinCross, SPSS, and Mentor Procedures for
+   Estimating the Variance of a Weighted Mean", A. Madansky, H. G. B. Alexander,
    www.analyticalgroup.com/download/weighted_variance.pdf
 '''
 
@@ -173,7 +173,7 @@ def find_optimal_block(ndata, stats):
 
 Inspect a reblocking calculation and find the block length which minimises the
 stochastic error and removes the effect of correlation from the data set.  This
-follows the procedures detailed by Wolff [2]_ and Lee et al. [3]_.
+follows the procedures detailed by [Wolff]_ and [Lee]_ et al.
 
 .. default-role:: math
 
@@ -194,7 +194,7 @@ list of int
 
 Notes
 -----
-Wolff [2]_ (Eq 47) and Lee et al. [3]_ (Eq 14) give the optimal block size to be
+[Wolff]_ (Eq 47) and [Lee]_ et al. (Eq 14) give the optimal block size to be
 
 .. math::
 
@@ -204,14 +204,14 @@ where `n` is the number of data points in the data set, `B` is the number of
 data points in each 'block' (ie the data set has been divided into `n/B`
 contiguous blocks) and `n_{\\text{corr}}`.
 [todo] - describe n_corr.
-Following the scheme proposed by Lee et al. [3]_, we hence look for the largest
+Following the scheme proposed by [Lee]_ et al., we hence look for the largest
 block size which satisfies 
 
 .. math::
 
     B^3 >= 2 n n_{\\text{corr}}^2.
 
-From Eq 13 in Lee et al. [3]_ (which they cast in terms of the variance):
+From Eq 13 in [Lee]_ et al. (which they cast in terms of the variance):
 
 .. math::
 
@@ -233,11 +233,11 @@ I am grateful to Will Vigor for discussions and the initial implementation.
 
 References
 ----------
-.. [2] "Monte Carlo errors with less errors", U. Wolff, Comput. Phys. Commun.
+.. [Wolff] "Monte Carlo errors with less errors", U. Wolff, Comput. Phys. Commun.
        156, 143 (2004) and arXiv:hep-lat/0306017.
-.. [3] "Strategies for improving the efficiency of quantum Monte Carlo
-       calculations", R. M. Lee, G. J. Conduit, N. Nemec, P. Lopez Rios, and N.
-       D.  Drummond, Phys. Rev. E. 83, 066706 (2011).
+.. [Lee] "Strategies for improving the efficiency of quantum Monte Carlo
+       calculations", R.M. Lee, G.J. Conduit, N. Nemec, P. Lopez Rios,
+       N.D.  Drummond, Phys. Rev. E. 83, 066706 (2011).
 '''
 
     # Get the number of variables by looking at the number of means calculated

--- a/pyblock/error.py
+++ b/pyblock/error.py
@@ -14,7 +14,7 @@ import pandas as pd
 import pyblock.pd_utils as pd_utils
 
 def ratio(stats_A, stats_B, cov_AB, data_len):
-    '''Calculate the mean and standard error of :math:`f = A/B`.
+    '''Calculate the mean and standard error of :math:`f(A,B) = A/B`.
 
 Parameters
 ----------
@@ -37,175 +37,91 @@ data_len : int or :class:`pandas.Series`
 
 Returns
 -------
-ratio_stats : :class:`pandas.Series` or :class:`pandas.DataFrame`
+stats : :class:`pandas.Series` or :class:`pandas.DataFrame`
     Mean and standard error (and, if possible/relevant, optimal reblock
-    iteration) for :math:`f = A/B`.  If ``stats_A``, ``stats_B`` are
+    iteration) for :math:`f(A,B)`.  If ``stats_A``, ``stats_B`` are
     :class:`pandas.DataFrame`, this is a :class:`pandas.DataFrame` with the
     same index, otherwise a :class:`pandas.Series` is returned.
 '''
-
-    return _quadratic(stats_A, stats_B, cov_AB, data_len, False, -1)
+    (m_A, m_B) = (stats_A['mean'], stats_B['mean'])
+    mean = m_A / m_B
+    (se_A, se_B) = (stats_A['standard error'], stats_B['standard error'])
+    std_err = abs(mean*numpy.sqrt(
+                (se_A/m_A)**2 + (se_B/m_B)**2 - 2*cov_AB/(data_len*m_A*m_B)
+              ))
+    return _stats_summary(mean, std_err, stats_A, stats_B)
 
 def product(stats_A, stats_B, cov_AB, data_len):
-    '''Calculate the mean and standard error of :math:`f = A \\times B`.
+    '''Calculate the mean and standard error of :math:`f(A,B) = A \\times B`.
 
 Parameters
 ----------
-stats_A : :class:`pandas.Series` or :class:`pandas.DataFrame`
-    Statistics (containing at least the 'mean' and 'standard error' fields) for
-    variable :math:`A`.  The rows contain different values of these statistics
-    (e.g. from a reblocking analysis) if :class:`pandas.DataFrame` are passed.
-stats_B : :class:`pandas.Series` or :class:`pandas.DataFrame`
-    Similarly for variable :math:`B`.
-cov_AB : float or :class:`pandas.Series`
-    Covariance between variables `A and B.  If ``stats_A`` and ``stats_B`` are
-    :class:`pandas.DataFrame`, then this must be a :class:`pandas.Series`, with
-    the same index as ``stats_A`` and ``stats_B``.
-data_len : int or :class:`pandas.Series`
-    Number of data points ('observations') used to obtain the statistics given
-    in ``stats_A`` and ``stats_B``.  If ``stats_A`` and ``stats_B`` are
-    :class:`pandas.DataFrame`, then this must be a :class:`pandas.Series`, with
-    the same index as ``stats_A`` and ``stats_B``.
+See :func:`ratio`.
 
 Returns
 -------
-product_stats : :class:`pandas.Series` or :class:`pandas.DataFrame`
-    Mean and standard error (and, if possible/relevant, optimal reblock
-    iteration) for :math:`f = A \\times B`.  If ``stats_A``, ``stats_B`` are
-    :class:`pandas.DataFrame`, this is a :class:`pandas.DataFrame` with the
-    same index, otherwise a :class:`pandas.Series` is returned.
+See :func:`ratio`.
+
 '''
+    (m_A, m_B) = (stats_A['mean'], stats_B['mean'])
+    mean = m_A * m_B
+    (se_A, se_B) = (stats_A['standard error'], stats_B['standard error'])
+    std_err = abs(mean*numpy.sqrt(
+                (se_A/m_A)**2 + (se_B/m_B)**2 + 2*cov_AB/(data_len*m_A*m_B)
+              ))
+    return _stats_summary(mean, std_err, stats_A, stats_B)
 
-    return _quadratic(stats_A, stats_B, cov_AB, data_len, False, 1)
-
-def difference(stats_A, stats_B, cov_AB, data_len):
-    '''Calculate the mean and standard error of :math:`f = A - B`.
+def subtraction(stats_A, stats_B, cov_AB, data_len):
+    '''Calculate the mean and standard error of :math:`f(A,B) = A - B`.
 
 Parameters
 ----------
-stats_A : :class:`pandas.Series` or :class:`pandas.DataFrame`
-    Statistics (containing at least the 'mean' and 'standard error' fields) for
-    variable :math:`A`.  The rows contain different values of these statistics
-    (e.g. from a reblocking analysis) if :class:`pandas.DataFrame` are passed.
-stats_B : :class:`pandas.Series` or :class:`pandas.DataFrame`
-    Similarly for variable :math:`B`.
-cov_AB : float or :class:`pandas.Series`
-    Covariance between variables `A and B.  If ``stats_A`` and ``stats_B`` are
-    :class:`pandas.DataFrame`, then this must be a :class:`pandas.Series`, with
-    the same index as ``stats_A`` and ``stats_B``.
-data_len : int or :class:`pandas.Series`
-    Number of data points ('observations') used to obtain the statistics given
-    in ``stats_A`` and ``stats_B``.  If ``stats_A`` and ``stats_B`` are
-    :class:`pandas.DataFrame`, then this must be a :class:`pandas.Series`, with
-    the same index as ``stats_A`` and ``stats_B``.
+See :func:`ratio`.
 
 Returns
 -------
-difference_stats : :class:`pandas.Series` or :class:`pandas.DataFrame`
-    Mean and standard error (and, if possible/relevant, optimal reblock
-    iteration) for :math:`f = A - B`.  If ``stats_A``, ``stats_B`` are
-    :class:`pandas.DataFrame`, this is a :class:`pandas.DataFrame` with the
-    same index, otherwise a :class:`pandas.Series` is returned.
+See :func:`ratio`.
 '''
-
-    return _quadratic(stats_A, stats_B, cov_AB, data_len, True, -1)
+    mean = stats_A['mean'] - stats_B['mean']
+    se = 'standard error'
+    std_err = stats_A[se]**2 + stats_B[se]**2 - 2*cov_AB/data_len
+    std_err = abs(numpy.sqrt(std_err))
+    return _stats_summary(mean, std_err, stats_A, stats_B)
 
 def addition(stats_A, stats_B, cov_AB, data_len):
-    '''Calculate the mean and standard error of :math:`f = A \\plus B`.
+    '''Calculate the mean and standard error of :math:`f(A,B) = A \\plus B`.
 
 Parameters
 ----------
-stats_A : :class:`pandas.Series` or :class:`pandas.DataFrame`
-    Statistics (containing at least the 'mean' and 'standard error' fields) for
-    variable :math:`A`.  The rows contain different values of these statistics
-    (e.g. from a reblocking analysis) if :class:`pandas.DataFrame` are passed.
-stats_B : :class:`pandas.Series` or :class:`pandas.DataFrame`
-    Similarly for variable :math:`B`.
-cov_AB : float or :class:`pandas.Series`
-    Covariance between variables `A and B.  If ``stats_A`` and ``stats_B`` are
-    :class:`pandas.DataFrame`, then this must be a :class:`pandas.Series`, with
-    the same index as ``stats_A`` and ``stats_B``.
-data_len : int or :class:`pandas.Series`
-    Number of data points ('observations') used to obtain the statistics given
-    in ``stats_A`` and ``stats_B``.  If ``stats_A`` and ``stats_B`` are
-    :class:`pandas.DataFrame`, then this must be a :class:`pandas.Series`, with
-    the same index as ``stats_A`` and ``stats_B``.
+See :func:`ratio`.
 
 Returns
 -------
-addition_stats : :class:`pandas.Series` or :class:`pandas.DataFrame`
-    Mean and standard error (and, if possible/relevant, optimal reblock
-    iteration) for :math:`f = A \\plus B`.  If ``stats_A``, ``stats_B`` are
-    :class:`pandas.DataFrame`, this is a :class:`pandas.DataFrame` with the
-    same index, otherwise a :class:`pandas.Series` is returned.
+See :func:`ratio`.
 '''
+    mean = stats_A['mean'] + stats_B['mean']
+    se = 'standard error'
+    std_err = stats_A[se]**2 + stats_B[se]**2 + 2*cov_AB/data_len
+    std_err = abs(numpy.sqrt(std_err))
+    return _stats_summary(mean, std_err, stats_A, stats_B)
 
-    return _quadratic(stats_A, stats_B, cov_AB, data_len, True, 1)
-
-def _quadratic(stats_A, stats_B, cov_AB, data_len, linear, sign):
-    '''Calculate the mean and standard error of :math:`f = g(A,B)`.
+def _stats_summary(mean, std_err, stats_A, stats_B):
+    '''Summarise error propogation.
 
 Parameters
 ----------
-stats_A : :class:`pandas.Series` or :class:`pandas.DataFrame`
-    Statistics (containing at least the 'mean' and 'standard error' fields) for
-    variable :math:`A`.  The rows contain different values of these statistics
-    (e.g. from a reblocking analysis) if :class:`pandas.DataFrame` are passed.
-stats_B : :class:`pandas.Series` or :class:`pandas.DataFrame`
-    Similarly for variable :math:`B`.
-cov_AB : float or :class:`pandas.Series`
-    Covariance between variables `A and B.  If ``stats_A`` and ``stats_B`` are
-    :class:`pandas.DataFrame`, then this must be a :class:`pandas.Series`, with
-    the same index as ``stats_A`` and ``stats_B``.
-data_len : int or :class:`pandas.Series`
-    Number of data points ('observations') used to obtain the statistics given
-    in ``stats_A`` and ``stats_B``.  If ``stats_A`` and ``stats_B`` are
-    :class:`pandas.DataFrame`, then this must be a :class:`pandas.Series`, with
-    the same index as ``stats_A`` and ``stats_B``.
-linear : bool
-    If true, do addition (if sign=1) or subtraction (if sign=-1). If false, do
-    multiplication (if sign=1) or division (if sign=-1).
-sign : int
-    :math:`g(A,B) = A*B` or :math:`g(A,B) = A+B` for sign=1 and :math:`f = A/B`
-    or :math:`f = A-B` for sign=-1.
+mean : float or :class:`pandas.Series`
+    mean of of :math:`f(A,B)`.
+std_err: float or :class:`pandas.Series`
+    standard error of :math:`f(A,B)`.
+stats_A, stats_B:
+    see `func:`ratio`.
 
 Returns
 -------
-func_data : :class:`pandas.Series` or :class:`pandas.DataFrame`
-    Mean and standard error (and, if possible/relevant, optimal reblock
-    iteration) for :math:`f = g(A,B)`.  If ``stats_A``, ``stats_B`` are
-    :class:`pandas.DataFrame`, this is a :class:`pandas.DataFrame` with the
-    same index, otherwise a :class:`pandas.Series` is returned.
 
-Raises
-------
-ValueError
-    ``sign`` is not +1 nor -1.
+See :func:`ratio`.
 '''
-
-    if sign not in (1,-1):
-        raise ValueError('sign must be either +1 or -1')
-    if linear:
-        mean = stats_A['mean'] + sign*stats_B['mean']
-        std_err = numpy.sqrt(
-                    (stats_A['standard error'])**2 + 
-                    (stats_B['standard error'])**2 +
-                    2*sign*cov_AB/data_len
-                )
-
-    else:
-        if sign == 1:
-            mean = stats_A['mean'] * stats_B['mean']
-        else:
-            mean = stats_A['mean'] / stats_B['mean']
-
-        std_err = mean*numpy.sqrt(
-                    (stats_A['standard error']/stats_A['mean'])**2 +
-                    (stats_B['standard error']/stats_B['mean'])**2 +
-                    2*sign*cov_AB/(data_len*stats_A['mean']*stats_B['mean'])
-                )
-    std_err = abs(std_err)
-
     stats_dict = dict( (('mean', mean), ('standard error', std_err)) )
     try:
         stats = pd.DataFrame(stats_dict)
@@ -219,7 +135,6 @@ ValueError
     except ValueError:
         # Were given a single data point rather than a set.
         stats = pd.Series(stats_dict)
-
     return stats
 
 def pretty_fmt_err(val, err):

--- a/pyblock/tests/test_error.py
+++ b/pyblock/tests/test_error.py
@@ -41,9 +41,19 @@ class ErrorTests(unittest.TestCase):
         benchmark = pd.Series({'mean':-0.00561329, 'standard error':0.01576336})
         for key in ('mean', 'standard error'):
             self.assertAlmostEqual(benchmark[key], product[key], 8)
+    def test_difference_single(self):
+        difference = pyblock.error.difference(self.reblock.ix[4,1], self.reblock.ix[4,2], self.cov_12[4], self.data_len[4])
+        benchmark = pd.Series({'mean':-0.27652270, 'standard error':0.17002344})
+        for key in ('mean', 'standard error'):
+            self.assertAlmostEqual(benchmark[key], difference[key], 8)
+    def test_addition_single(self):
+        addition = pyblock.error.addition(self.reblock.ix[4,1], self.reblock.ix[4,2], self.cov_12[4], self.data_len[4])
+        benchmark = pd.Series({'mean':0.23240407, 'standard error':0.06664526})
+        for key in ('mean', 'standard error'):
+            self.assertAlmostEqual(benchmark[key], addition[key], 8)
     def test_quad_raise(self):
         with self.assertRaises(ValueError):
-            pyblock.error._quadratic(self.reblock[1], self.reblock[2], self.cov_12, self.data_len, 2)
+            pyblock.error._quadratic(self.reblock[1], self.reblock[2], self.cov_12, self.data_len, True, 2)
 
 
 class ErrorFmtTests(unittest.TestCase):

--- a/pyblock/tests/test_error.py
+++ b/pyblock/tests/test_error.py
@@ -41,20 +41,16 @@ class ErrorTests(unittest.TestCase):
         benchmark = pd.Series({'mean':-0.00561329, 'standard error':0.01576336})
         for key in ('mean', 'standard error'):
             self.assertAlmostEqual(benchmark[key], product[key], 8)
-    def test_difference_single(self):
-        difference = pyblock.error.difference(self.reblock.ix[4,1], self.reblock.ix[4,2], self.cov_12[4], self.data_len[4])
+    def test_subtraction_single(self):
+        subtraction = pyblock.error.subtraction(self.reblock.ix[4,1], self.reblock.ix[4,2], self.cov_12[4], self.data_len[4])
         benchmark = pd.Series({'mean':-0.27652270, 'standard error':0.17002344})
         for key in ('mean', 'standard error'):
-            self.assertAlmostEqual(benchmark[key], difference[key], 8)
+            self.assertAlmostEqual(benchmark[key], subtraction[key], 8)
     def test_addition_single(self):
         addition = pyblock.error.addition(self.reblock.ix[4,1], self.reblock.ix[4,2], self.cov_12[4], self.data_len[4])
         benchmark = pd.Series({'mean':0.23240407, 'standard error':0.06664526})
         for key in ('mean', 'standard error'):
             self.assertAlmostEqual(benchmark[key], addition[key], 8)
-    def test_quad_raise(self):
-        with self.assertRaises(ValueError):
-            pyblock.error._quadratic(self.reblock[1], self.reblock[2], self.cov_12, self.data_len, True, 2)
-
 
 class ErrorFmtTests(unittest.TestCase):
     def test1(self):


### PR DESCRIPTION
1. Split the code for error propagation into a helper function for creating the Series/DataFrame to return and code for actual calculation of the mean and standard error.
2. Remove _quadratic in favour of explicit calculation.
3. Add error propagation for additon and subtraction.

Original code + tests from @verena-neufeld 

(Also some minor doc formatting fixes.)