### PR TITLE
Correct initialisation of optimal_block column.

### DIFF
--- a/pyblock/pd_utils.py
+++ b/pyblock/pd_utils.py
@@ -79,7 +79,7 @@ See also
     keys = ['mean', 'standard error', 'standard error error', 'optimal block']
     multi_keys = [(col,k) for col in columns for k in keys]
     multi_keys = pd.MultiIndex.from_tuples(multi_keys)
-    null = numpy.zeros(len(columns))
+    null = numpy.zeros_like(block_stats[0].mean)
     for stat in block_stats:
         # Contents of stat:
         #     (iblock, data_len, mean, covariance, standard err,

--- a/pyblock/tests/test_pd_utils.py
+++ b/pyblock/tests/test_pd_utils.py
@@ -32,6 +32,9 @@ class BlockingTests1D(pdBlockTest):
     def test_pdblock(self):
         (data_len, reblock, cov) = pyblock.pd_utils.reblock(self.data)
         self.check_stats(data_len, reblock, cov, tests_base.reblock_1D)
+    def test_pdblock_df(self):
+        (data_len, reblock, cov) = pyblock.pd_utils.reblock(pd.DataFrame(self.data))
+        self.check_stats(data_len, reblock, cov, tests_base.reblock_1D)
     def test_pdblock_opt(self):
         (data_len, reblock, cov) = pyblock.pd_utils.reblock(self.data)
         self.assertEqual(pyblock.pd_utils.optimal_block(reblock), tests_base.reblock_1D_opt[0])


### PR DESCRIPTION
Previously it was always at least a 1-D array for each block size whilst
blocking used 0-D arrays for each block size if the input data was a 1-D
array. Resolve this discrepancy.