### PR TITLE
Revamp infrastructure

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,14 @@
+# Codecov configuration to make it a bit less noisy
+coverage:
+  status:
+    patch: false
+    project:
+      default:
+        threshold: 85%
+comment:
+  layout: "header"
+  require_changes: false
+  branches: null
+  behavior: default
+  flags: null
+  paths: null

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip coverage pytest numpy matplotlib pandas
           python -m pip install -e .
-      - name: Test with nose
+      - name: Test with pytest
         run: |
-          python -m pytest --cov=pyblock --cov-report=xml --pyargs=pyblock
+          python -m pytest --cov=pyblock --cov-report=xml pyblock

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip coverage nose numpy matplotlib pandas
+          python -m pip install --upgrade pip coverage pytest numpy matplotlib pandas
           python -m pip install -e .
       - name: Test with nose
         run: |
-          python -m nosetests --with-coverage --cover-package=pyblock --cover-min-percentage=85 pyblock
+          python -m pytest --cov=pyblock --cov-report=xml --pyargs=pyblock

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip coverage pytest numpy matplotlib pandas
+          python -m pip install --upgrade pip codecov coverage pytest pytest-cov numpy matplotlib pandas
           python -m pip install -e .
       - name: Test with pytest
         run: |
-          python -m pytest pyblock
+          python -m pytest pyblock --cov=pyblock --cov-report=xml --doctest-modules
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,4 +32,4 @@ jobs:
           python -m pip install -e .
       - name: Test with pytest
         run: |
-          python -m pytest --cov=pyblock --cov-report=xml pyblock
+          python -m pytest pyblock

--- a/README.rst
+++ b/README.rst
@@ -10,9 +10,6 @@ references.
 pyblock is compatible with (and tested on!) python 2.7 and python 3.3-3.4 and should work
 on any other version supported by `pandas`.
 
-.. image:: https://travis-ci.org/jsspencer/pyblock.svg?branch=master
-    :target: https://travis-ci.org/jsspencer/pyblock
-
 .. image:: https://img.shields.io/pypi/v/pyblock.svg
         :target: https://pypi.python.org/pypi/pyblock
 

--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,20 @@ on any other version supported by `pandas`.
 .. image:: https://travis-ci.org/jsspencer/pyblock.svg?branch=master
     :target: https://travis-ci.org/jsspencer/pyblock
 
+.. image:: https://img.shields.io/pypi/v/pyblock.svg
+        :target: https://pypi.python.org/pypi/pyblock
+
+.. image:: https://github.com/jsspencer/pyblock/workflows/Test%20pyblock/badge.svg?branch=master
+        :target: https://github.com/jsspencer/pyblock/actions?query=workflow%3A%22Test+pyblock%22+branch%3Amaster
+        :alt: CI build status
+        
+.. image:: https://codecov.io/gh/jsspencer/pyblock/branch/master/graph/badge.svg
+  :target: https://codecov.io/gh/jsspencer/pyblock
+
+.. image:: https://readthedocs.org/projects/pyblock/badge/?version=latest
+        :target: https://pyblock.readthedocs.io/en/latest/?badge=latest
+        :alt: Documentation Status
+
 Documentation
 -------------
 


### PR DESCRIPTION
- [X] Use `pytest` instead of `nose`.
- [x] Integrate with codecov for code coverage reporting.